### PR TITLE
Feat/73 dupe radar

### DIFF
--- a/src/main/frontend/src/components/radars/RadarCard.vue
+++ b/src/main/frontend/src/components/radars/RadarCard.vue
@@ -29,6 +29,7 @@
 
     <div class="actions">
       <button class="edit-btn" @click="$emit('edit', radar)">Edit</button>
+      <button class="duplicate-btn" @click="duplicate">Duplicate</button>
       <button class="delete-btn" @click="ask=true">🗑️</button>
     </div>
 
@@ -44,6 +45,7 @@
 <script>
 import ConfirmModal from '@/components/ui/ConfirmModal.vue'
 import service      from '@/services/radarService'
+import {deepClone} from "@/utils/deepClone.js";
 
 export default {
   components:{ ConfirmModal },
@@ -51,6 +53,29 @@ export default {
   emits:['deleted','edit'],
   data:()=>({ ask:false }),
   methods:{
+    goToRadar(){
+      this.$router.push({ name: 'radar', params: { id: this.radar.id } })
+    },
+    duplicate(){
+      const clone = deepClone(this.radar)
+      delete clone.id
+      clone.quadrants.forEach(q => delete q.id)
+      clone.rings.forEach(r => delete r.id)
+
+      if (clone.entries) {
+        clone.entries = this.radar.entries.map(e => ({
+          label: e.label,
+          quadrant: e.quadrant,
+          ring: e.ring,
+          moved: e.moved,
+          active: e.active,
+          year: e.year,
+        }))
+        clone.entries.forEach(e => delete e.id)
+      }
+      console.log(clone)
+      this.$emit('edit', clone)
+    },
     async remove(){
       this.ask=false
       await service.remove(this.radar.id)

--- a/src/main/frontend/src/components/radars/RadarsList.vue
+++ b/src/main/frontend/src/components/radars/RadarsList.vue
@@ -14,7 +14,7 @@
           v-for="r in radars"
           :key="r.id ?? r._stubId"
           :radar="r"
-          @edit="editing = clone(r)"
+          @edit="editing = clone($event)"
           @deleted="remove"
       />
     </div>
@@ -28,6 +28,7 @@ import { genId } from '@/utils/uuid'
 import service from '@/services/radarService'
 import RadarCard from '@/components/radars/RadarCard.vue'
 import RadarEditor from '@/components/radars/RadarEditor.vue'
+import {deepClone} from "@/utils/deepClone.js";
 
 export default {
   components: { RadarCard, RadarEditor },
@@ -44,7 +45,7 @@ export default {
       this.loading = false
     },
     clone(o) {
-      return JSON.parse(JSON.stringify(o))
+      return deepClone(o)
     },
     newRadar() {
       this.editing = {
@@ -62,7 +63,7 @@ export default {
     remove(id) {
       this.radars = this.radars.filter(r => r.id !== id)
     },
-    async handleEditorClose(updatedRadar) {
+    async handleEditorClose() {
       this.editing = null
       await this.reload()
     }

--- a/src/main/java/ch/sobrado/radar/Quadrant.java
+++ b/src/main/java/ch/sobrado/radar/Quadrant.java
@@ -1,7 +1,6 @@
 package ch.sobrado.radar;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import jakarta.persistence.*;
@@ -22,6 +21,7 @@ public class Quadrant extends PanacheEntity {
 
     @ManyToOne
     @JoinColumn(name = "radar_id", nullable = false)
+    @JsonBackReference
     public Radar radar;
 
     @PrePersist

--- a/src/main/java/ch/sobrado/radar/Quadrant.java
+++ b/src/main/java/ch/sobrado/radar/Quadrant.java
@@ -13,7 +13,7 @@ import jakarta.validation.ValidationException;
                 @UniqueConstraint(columnNames = {"name", "radar_id"})
         }
 )
-@JsonIgnoreProperties("radar")
+@JsonIgnoreProperties({"radar"})
 public class Quadrant extends PanacheEntity {
 
     @Column(nullable = false)
@@ -21,7 +21,6 @@ public class Quadrant extends PanacheEntity {
 
     @ManyToOne
     @JoinColumn(name = "radar_id", nullable = false)
-    @JsonBackReference
     public Radar radar;
 
     @PrePersist

--- a/src/main/java/ch/sobrado/radar/Radar.java
+++ b/src/main/java/ch/sobrado/radar/Radar.java
@@ -26,12 +26,18 @@ public class Radar extends PanacheEntity {
     @OneToMany(mappedBy = "radar", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @OrderColumn(name = "quadrant_order")
     @Size(min = 4, max = 4, message = "Radar must have 4 quadrants")
+    @JsonManagedReference
     public List<Quadrant> quadrants = new ArrayList<>();
 
     @OneToMany(mappedBy = "radar", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @OrderColumn(name = "ring_order")
     @Size(min = 4, max = 4, message = "Radar must have 4 rings")
+    @JsonManagedReference
     public List<Ring> rings = new ArrayList<>();
+
+    @OneToMany(mappedBy = "radar", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @JsonManagedReference
+    public List<RadarEntry> entries = new ArrayList<>();
 
     public void addRing(Ring ring) {
         ring.radar = this;

--- a/src/main/java/ch/sobrado/radar/Radar.java
+++ b/src/main/java/ch/sobrado/radar/Radar.java
@@ -26,13 +26,11 @@ public class Radar extends PanacheEntity {
     @OneToMany(mappedBy = "radar", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @OrderColumn(name = "quadrant_order")
     @Size(min = 4, max = 4, message = "Radar must have 4 quadrants")
-    @JsonManagedReference
     public List<Quadrant> quadrants = new ArrayList<>();
 
     @OneToMany(mappedBy = "radar", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @OrderColumn(name = "ring_order")
     @Size(min = 4, max = 4, message = "Radar must have 4 rings")
-    @JsonManagedReference
     public List<Ring> rings = new ArrayList<>();
 
     @OneToMany(mappedBy = "radar", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)

--- a/src/main/java/ch/sobrado/radar/RadarEntry.java
+++ b/src/main/java/ch/sobrado/radar/RadarEntry.java
@@ -1,8 +1,6 @@
 package ch.sobrado.radar;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import jakarta.persistence.*;
 
@@ -14,6 +12,7 @@ public class RadarEntry extends PanacheEntity {
 
     @ManyToOne
     @JoinColumn(name = "radar_id")
+    @JsonBackReference
     public Radar radar;
 
     @ManyToOne

--- a/src/main/java/ch/sobrado/radar/RadarResource.java
+++ b/src/main/java/ch/sobrado/radar/RadarResource.java
@@ -56,6 +56,13 @@ public class RadarResource {
             ring.radar = radar;
         }
         radar.persist();
+        for(RadarEntry entry : radar.entries) {
+            Quadrant quadrant = Quadrant.find("name = ?1 and radar.id = ?2", entry.quadrant.name, radar.id).firstResult();
+            Ring ring = Ring.find("name = ?1 and radar.id = ?2", entry.ring.name, radar.id).firstResult();
+            entry.quadrant = quadrant;
+            entry.ring = ring;
+            entry.persist();
+        }
         return Response.status(Response.Status.CREATED)
                 .entity(Collections.singletonMap("id", radar.id))
                 .build();

--- a/src/main/java/ch/sobrado/radar/Ring.java
+++ b/src/main/java/ch/sobrado/radar/Ring.java
@@ -18,6 +18,7 @@ import java.util.List;
                 @UniqueConstraint(columnNames = {"name", "radar_id"})
         }
 )
+@JsonIgnoreProperties({"radar"})
 public class Ring extends PanacheEntity {
 
     @Column(nullable = false)
@@ -25,7 +26,6 @@ public class Ring extends PanacheEntity {
 
     @ManyToOne
     @JoinColumn(name = "radar_id", nullable = false)
-    @JsonBackReference
     public Radar radar;
 
     @PrePersist

--- a/src/main/java/ch/sobrado/radar/Ring.java
+++ b/src/main/java/ch/sobrado/radar/Ring.java
@@ -3,9 +3,13 @@ package ch.sobrado.radar;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import jakarta.persistence.*;
 import jakarta.validation.ValidationException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(
@@ -14,7 +18,6 @@ import jakarta.validation.ValidationException;
                 @UniqueConstraint(columnNames = {"name", "radar_id"})
         }
 )
-@JsonIgnoreProperties("radar")
 public class Ring extends PanacheEntity {
 
     @Column(nullable = false)
@@ -22,6 +25,7 @@ public class Ring extends PanacheEntity {
 
     @ManyToOne
     @JoinColumn(name = "radar_id", nullable = false)
+    @JsonBackReference
     public Radar radar;
 
     @PrePersist


### PR DESCRIPTION
This pull request introduces a "Duplicate Radar" feature in the frontend and makes backend adjustments to support radar entries and their relationships. The key changes include adding a duplicate button in the UI, implementing radar duplication logic, improving deep cloning functionality, and updating the backend to handle radar entries and their persistence.

### Frontend Changes

**Duplicate Radar Feature:**
* [`src/main/frontend/src/components/radars/RadarCard.vue`](diffhunk://#diff-3335b9621d59dd959d7e9397c58e99b4be73c20ee7ff07d9d59577d7b7c2c322R32): Added a "Duplicate" button to the radar card and implemented a `duplicate` method to create a deep copy of a radar, excluding IDs and preserving the structure of its entries, quadrants, and rings.

**UI Behavior Adjustments:**
* [`src/main/frontend/src/components/radars/RadarsList.vue`](diffhunk://#diff-20d71d958149dfc637c2feee3789e8df175bb9d02132257b2a99d14b3cfc813eL17-R17): Updated the `@edit` event handler to directly use the emitted radar object instead of cloning it again.

### Backend Changes

**Radar Entries Management:**
* [`src/main/java/ch/sobrado/radar/Radar.java`](diffhunk://#diff-4d8cfb47bff21b6139aef9495e3989694e2afdc2495c1d0768f92e75114aeab0R36-R39): Added a `List<RadarEntry>` to the `Radar` class with proper JPA annotations to manage radar entries and ensure they are eagerly fetched and cascade-persisted.
This also fixed #65 

* [`src/main/java/ch/sobrado/radar/RadarResource.java`](diffhunk://#diff-19bb9c88bb0586bc25018f0e4238b8e7da14c330a07201baed121adddf7a43d1R59-R65): Updated the radar creation logic to correctly associate radar entries with their respective quadrants and rings before persisting them.

**Entity Annotations and Relationships:**
* [`src/main/java/ch/sobrado/radar/RadarEntry.java`](diffhunk://#diff-891c0df010cd0fbe15116c1174819b00f60128461659932b4a5ea6d6bb697b02R15): Added `@JsonBackReference` to the `radar` field to manage bidirectional serialization.
* `src/main/java/ch/sobrado/radar/Ring.java` and `src/main/java/ch/sobrado/radar/Quadrant.java`: Updated `@JsonIgnoreProperties` annotations for better handling of nested JSON structures.

Closes #73 